### PR TITLE
RPC: New --api-limit-fee option to enforce a limit on how much hashing certain pools can be used for

### DIFF
--- a/API-README
+++ b/API-README
@@ -43,6 +43,9 @@ A sample API group would be:
 This would create a group 'P' that can do all current pool commands and all
 non-priviliged commands - the '*' means all non-priviledged commands
 Without the '*' the group would only have access to the pool commands
+If the addpool command is listed followed by a percent symbol ('%'), all pools
+added by this group will be limited (overall) to the hashrate ratio specified
+by the "--api-fee-limit" option.
 Defining multiple groups example:
  --api-groups Q:quit:restart:*,S:save
 This would define 2 groups:

--- a/README
+++ b/README
@@ -121,6 +121,7 @@ Options for both config file and command line:
 --api-description   Description placed in the API status header (default: cgminer version)
 --api-groups        API one letter groups G:cmd:cmd[,P:cmd:*...]
                     See API-README for usage
+--api-limit-fee     Hash ratio limit placed on pools added by limited API connections (default: 0.05)
 --api-listen        Listen for API requests (default: disabled)
                     By default any command that does not just display data returns access denied
                     See --api-allow to overcome this

--- a/miner.h
+++ b/miner.h
@@ -599,7 +599,7 @@ extern void api(int thr_id);
 
 extern struct pool *current_pool(void);
 extern int active_pools(void);
-extern void add_pool_details(bool live, char *url, char *user, char *pass);
+extern struct pool *add_pool_details(bool live, char *url, char *user, char *pass);
 
 #define MAX_GPUDEVICES 16
 
@@ -681,6 +681,7 @@ enum pool_enable {
 	POOL_ENABLED,
 	POOL_DISABLED,
 	POOL_REJECTING,
+	POOL_LIMITED,
 };
 
 struct pool {
@@ -697,6 +698,7 @@ struct pool {
 	enum pool_enable enabled;
 	bool submit_old;
 	bool removed;
+	bool limited;
 	bool lp_started;
 
 	char *hdr_path;


### PR DESCRIPTION
If the addpool command is listed followed by a percent symbol ('%'), all pools added by this group will be limited (overall) to the hashrate ratio specified by the "--api-fee-limit" option.

**Status:** Not yet tested. Waiting on P4man to coordinate. Please feel free to comment on what you think needs changing in the meantime.
