### PR TITLE
Mark pool as idle if stratum restart is failed

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -1453,6 +1453,7 @@ extern bool log_curses_only(int prio, const char *datetime, const char *str);
 extern void clear_logwin(void);
 extern void logwin_update(void);
 extern bool pool_tclear(struct pool *pool, bool *var);
+extern void pool_failed(struct pool *pool);
 extern struct thread_q *tq_new(void);
 extern void tq_free(struct thread_q *tq);
 extern bool tq_push(struct thread_q *tq, void *data);

--- a/util.c
+++ b/util.c
@@ -1900,8 +1900,10 @@ static bool parse_reconnect(struct pool *pool, json_t *val)
 	free(tmp);
 	mutex_unlock(&pool->stratum_lock);
 
-	if (!restart_stratum(pool))
+	if (!restart_stratum(pool)) {
+		pool_failed(pool);
 		return false;
+	}
 
 	return true;
 }


### PR DESCRIPTION
This happends when stratum restarted (server failure or network outage), and after miner cannot subscribe/auth.
