### PR TITLE
MXE build fails on WSL1 due to python

### DIFF
--- a/windows-build.txt
+++ b/windows-build.txt
@@ -1,6 +1,6 @@
 Building cgminer on Windows 10
 ------------------------------
-
+edit
 One way to build cgminer on Windows 10 is to use
  WSL - Windows Subsystem for Linux
 


### PR DESCRIPTION
All Testing in WSLv1

Recently I tried to install your kanoi/cgminer using the windows build instructions and  ran into problems with MXE
MXE hard codes python  calls,  see the following 
https://github.com/mxe/mxe/blob/build-2020-06-06/Makefile#L40
https://github.com/mxe/mxe/blob/build-2020-06-06/Makefile#L53
https://github.com/mxe/mxe/blob/build-2020-06-06/Makefile#L800

Unfortunately 
sudo apt-get install python doesnt work anymore (a couple months ago I had no problems)
E: Package 'python' has no installation candidate

this resulting in breaking the command
 ./mxe.sh a   

I haven't found a workaround

see relevant
https://codesti.com/issue/mxe/mxe/2838