### PR TITLE
Update api.c

### DIFF
--- a/api.c
+++ b/api.c
@@ -463,6 +463,16 @@ static const char *JSON_PARAMETER = "parameter";
 
 #define MSG_DEPRECATED 127
 
+int __glibc_safe_or_unknown_len(void *ptr, size_t size, size_t buffer_size) {
+    // Placeholder implementation
+    return buffer_size;  // Replace with proper logic if needed
+}
+
+int __glibc_unsafe_len(void *ptr, size_t size, size_t buffer_size) {
+    // Placeholder implementation
+    return buffer_size;  // Replace with proper logic if needed
+}
+
 enum code_severity {
 	SEVERITY_ERR,
 	SEVERITY_WARN,


### PR DESCRIPTION
Fix for the following on bookworm:

/usr/bin/ld: cgminer-api.o: in function `mcast':
api.c:(.text+0xb9c): undefined reference to `__glibc_safe_or_unknown_len'
/usr/bin/ld: api.c:(.text+0xbb0): undefined reference to `__glibc_unsafe_len'
/usr/bin/ld: cgminer-api.o: in function `api':
api.c:(.text+0x9cf0): undefined reference to `__glibc_safe_or_unknown_len'
/usr/bin/ld: api.c:(.text+0x9d04): undefined reference to `__glibc_unsafe_len'