### PR TITLE
A1,F Fullscan corrections

### DIFF
--- a/driver-gekko.c
+++ b/driver-gekko.c
@@ -6069,7 +6069,7 @@ applog(LOG_ERR, "DBG BF expect 1 chip");
 		case BM1362:
 			info->rx_len = 11;
 			info->task_len = 86;
-			info->cores = 512;
+			info->cores = 514;
 			info->min_job_id = 0x10;
 			info->add_job_id = 0x08;
 			info->max_job_id = 0x78;


### PR DESCRIPTION
There are 3 things

1. cores 512 to 514

2. fullscan for BM1397
i have tested extensively and dups appear at 83886us for a fullscan of the BM1397

3. fullscan for BM1362
duplicates are dependant on register 0x10 HCN, and the version mask you send to the chip
for the default HCN 0x12c9,  3.36 seconds
in the original cgminer equation 3.57 is the limit 
meaning there are duplicates at waitfactor 0.95+

the equations will cause wait factor to be properly normalised 
at wait factor=1 dups will appear, 

Detecting Dups for A1
dups wont be detected at the chip level ever because the dup check only checks the last nonce, you would need to collect many more nonces
you collect diff 16, the ticket mask settles at this number
there are 21010840 of nonce space(due to HCN), 65K version 
21010840 * 65536/ 2^32 / 16 = 20 
20 diff 16 nonces of history by expectation, you would need to test dups on the a larger history than 1
