### PR TITLE
Fix: Build and run cgminer on Raspberry Pi 5 (Debian 12, Pi OS 2025) – Changes to api.c and util.c

### DIFF
--- a/util.c
+++ b/util.c
@@ -688,10 +688,10 @@ json_t *json_rpc_call(CURL *curl, const char *url,
 	}
 
 	pool->cgminer_pool_stats.times_sent++;
-	if (curl_easy_getinfo(curl, CURLINFO_SIZE_UPLOAD, &byte_count) == CURLE_OK)
+	if (curl_easy_getinfo(curl, CURLINFO_SIZE_UPLOAD_T, &byte_count) == CURLE_OK) // FIXXXME CURLINFO_SIZE_UPLOAD
 		pool->cgminer_pool_stats.bytes_sent += byte_count;
 	pool->cgminer_pool_stats.times_received++;
-	if (curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD, &byte_count) == CURLE_OK)
+	if (curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD_T, &byte_count) == CURLE_OK) // FIXXXME CURLINFO_SIZE_DOWNLOAD
 		pool->cgminer_pool_stats.bytes_received += byte_count;
 
 	if (probing) {


### PR DESCRIPTION
### Description:

This Pull Request updates `api.c` and `util.c` to allow `cgminer` to build and run correctly on the **Raspberry Pi 5** under the current **Raspberry Pi OS (Debian 12, "bookworm")**.

**System Information:**
```
Raspberry Pi 5 Model B Rev 1.0
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
Kernel: 6.12.20+rpt-rpi-2712 (aarch64)
Compiler: GCC 12.2.0 (Debian 12.2.0-14)
```
Raspberry Pi reference build: 2024-11-19 (pi-gen 891df1e21ed2b6099a2e6a13e26c91dea44b34d4, stage4)

**Configure Command:**
```bash
./configure --enable-gekko --enable-usbutils CFLAGS="-O2 -Wall -march=native -fcommon"
```
Target Device: **GekkoScience F USB miner**

---

### Changes Made:

- **api.c**: Adjustments for compatibility with updated compiler toolchain and system libraries.
- **util.c**: Minor fixes to resolve build issues on `aarch64` architecture and stricter Pi OS settings.

---

### Motivation:

The build process on Raspberry Pi 5 previously failed due to system-level changes (GCC flags, architecture differences, stricter warnings).  
These adjustments ensure that `cgminer` remains buildable and usable on current and future Raspberry Pi systems.

---

### Testing:

- Built and verified functionality on Raspberry Pi 5 (64-bit Debian Bookworm).
- Successfully connected and mined using a GekkoScience USB device.

---

### Notes:

- No changes outside of `api.c` and `util.c`.
- No behavioral changes for existing architectures or platforms expected.
- If desired, further testing on x86_64 or other ARM boards can be performed, but no regressions anticipated.

---

### Final Thought:

Thank you for maintaining `cgminer`.  
If needed, I can split the changes into smaller commits or provide additional Raspberry Pi-specific documentation.

