### PR TITLE
Fix build failures on Ubuntu 24.04 due to driver symbol redefinitions and missing guards

### DIFF
--- a/compat/jansson-2.9/jansson_private_config.h.in
+++ b/compat/jansson-2.9/jansson_private_config.h.in
@@ -30,11 +30,8 @@
 /* Define to 1 if you have the <locale.h> header file. */
 #undef HAVE_LOCALE_H
 
-/* Define to 1 if the system has the type 'long long int'. */
+/* Define to 1 if the system has the type `long long int'. */
 #undef HAVE_LONG_LONG_INT
-
-/* Define to 1 if you have the <memory.h> header file. */
-#undef HAVE_MEMORY_H
 
 /* Define to 1 if you have the `open' function. */
 #undef HAVE_OPEN
@@ -50,6 +47,9 @@
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#undef HAVE_STDIO_H
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #undef HAVE_STDLIB_H
@@ -81,7 +81,7 @@
 /* Define to 1 if you have the <unistd.h> header file. */
 #undef HAVE_UNISTD_H
 
-/* Define to 1 if the system has the type 'unsigned long long int'. */
+/* Define to 1 if the system has the type `unsigned long long int'. */
 #undef HAVE_UNSIGNED_LONG_LONG_INT
 
 /* Number of buckets new object hashtables contain is 2 raised to this power.
@@ -112,7 +112,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #undef STDC_HEADERS
 
 /* Define to 1 if /dev/urandom should be used for seeding the hash function */

--- a/compat/jansson-2.9/test-driver
+++ b/compat/jansson-2.9/test-driver
@@ -3,7 +3,7 @@
 
 scriptversion=2018-03-07.03; # UTC
 
-# Copyright (C) 2011-2018 Free Software Foundation, Inc.
+# Copyright (C) 2011-2021 Free Software Foundation, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -42,11 +42,13 @@ print_usage ()
 {
   cat <<END
 Usage:
-  test-driver --test-name=NAME --log-file=PATH --trs-file=PATH
-              [--expect-failure={yes|no}] [--color-tests={yes|no}]
-              [--enable-hard-errors={yes|no}] [--]
+  test-driver --test-name NAME --log-file PATH --trs-file PATH
+              [--expect-failure {yes|no}] [--color-tests {yes|no}]
+              [--enable-hard-errors {yes|no}] [--]
               TEST-SCRIPT [TEST-SCRIPT-ARGUMENTS]
+
 The '--test-name', '--log-file' and '--trs-file' options are mandatory.
+See the GNU Automake documentation for information.
 END
 }
 
@@ -103,8 +105,11 @@ trap "st=130; $do_exit" 2
 trap "st=141; $do_exit" 13
 trap "st=143; $do_exit" 15
 
-# Test script is run here.
-"$@" >$log_file 2>&1
+# Test script is run here. We create the file first, then append to it,
+# to ameliorate tests themselves also writing to the log file. Our tests
+# don't, but others can (automake bug#35762).
+: >"$log_file"
+"$@" >>"$log_file" 2>&1
 estatus=$?
 
 if test $enable_hard_errors = no && test $estatus -eq 99; then
@@ -126,7 +131,7 @@ esac
 # know whether the test passed or failed simply by looking at the '.log'
 # file, without the need of also peaking into the corresponding '.trs'
 # file (automake bug#11814).
-echo "$res $test_name (exit status: $estatus)" >>$log_file
+echo "$res $test_name (exit status: $estatus)" >>"$log_file"
 
 # Report outcome to console.
 echo "${col}${res}${std}: $test_name"

--- a/miner.h
+++ b/miner.h
@@ -252,47 +252,234 @@ static inline int fsync (int fd)
  * trying to claim same chip but different devices. Adding a device here will
  * update all macros in the code that use the *_PARSE_COMMANDS macros for each
  * listed driver. */
+
+#ifdef USE_BITFORCE
+#define DRIVER_bitforce(X) X(bitforce)
+#else
+#define DRIVER_bitforce(X)
+#endif
+
+#ifdef USE_MODMINER
+#define DRIVER_modminer(X) X(modminer)
+#else
+#define DRIVER_modminer(X)
+#endif
+
+#ifdef USE_ANT_S1
+#define DRIVER_ants1(X) X(ants1)
+#else
+#define DRIVER_ants1(X)
+#endif
+
+#ifdef USE_ANT_S2
+#define DRIVER_ants2(X) X(ants2)
+#else
+#define DRIVER_ants2(X)
+#endif
+
+#ifdef USE_ANT_S3
+#define DRIVER_ants3(X) X(ants3)
+#else
+#define DRIVER_ants3(X)
+#endif
+
+#ifdef USE_AVALON
+#define DRIVER_avalon(X) X(avalon)
+#else
+#define DRIVER_avalon(X)
+#endif
+
+#ifdef USE_AVALON2
+#define DRIVER_avalon2(X) X(avalon2)
+#else
+#define DRIVER_avalon2(X)
+#endif
+
+#ifdef USE_AVALON4
+#define DRIVER_avalon4(X) X(avalon4)
+#else
+#define DRIVER_avalon4(X)
+#endif
+
+#ifdef USE_AVALON7
+#define DRIVER_avalon7(X) X(avalon7)
+#else
+#define DRIVER_avalon7(X)
+#endif
+
+#ifdef USE_AVALON8
+#define DRIVER_avalon8(X) X(avalon8)
+#else
+#define DRIVER_avalon8(X)
+#endif
+
+#ifdef USE_AVALON_MINER
+#define DRIVER_avalonm(X) X(avalonm)
+#else
+#define DRIVER_avalonm(X)
+#endif
+
+#ifdef USE_BAB
+#define DRIVER_bab(X) X(bab)
+#else
+#define DRIVER_bab(X)
+#endif
+
+#ifdef USE_BFLSC
+#define DRIVER_bflsc(X) X(bflsc)
+#else
+#define DRIVER_bflsc(X)
+#endif
+
+#ifdef USE_BITFURY
+#define DRIVER_bitfury(X) X(bitfury)
+#else
+#define DRIVER_bitfury(X)
+#endif
+
+#ifdef USE_BITFURY16
+#define DRIVER_bitfury16(X) X(bitfury16)
+#else
+#define DRIVER_bitfury16(X)
+#endif
+
+#ifdef USE_BITMINE_A1
+#define DRIVER_bitmineA1(X) X(bitmineA1)
+#else
+#define DRIVER_bitmineA1(X)
+#endif
+
+#ifdef USE_BLOCKERUPTER
+#define DRIVER_blockerupter(X) X(blockerupter)
+#else
+#define DRIVER_blockerupter(X)
+#endif
+
+#ifdef USE_COINTERRA
+#define DRIVER_cointerra(X) X(cointerra)
+#else
+#define DRIVER_cointerra(X)
+#endif
+
+#ifdef USE_FLOW
+#define DRIVER_flow(X) X(flow)
+#else
+#define DRIVER_flow(X)
+#endif
+
+#ifdef USE_GEKKO
+#define DRIVER_gekko(X) X(gekko)
+#else
+#define DRIVER_gekko(X)
+#endif
+
+#ifdef USE_DRAGONMINT_T1
+#define DRIVER_dragonmintT1(X) X(dragonmintT1)
+#else
+#define DRIVER_dragonmintT1(X)
+#endif
+
+#ifdef USE_HASHFAST
+#define DRIVER_hashfast(X) X(hashfast)
+#else
+#define DRIVER_hashfast(X)
+#endif
+
+#ifdef USE_DRILLBIT
+#define DRIVER_drillbit(X) X(drillbit)
+#else
+#define DRIVER_drillbit(X)
+#endif
+
+#ifdef USE_HASHRATIO
+#define DRIVER_hashratio(X) X(hashratio)
+#else
+#define DRIVER_hashratio(X)
+#endif
+
+#ifdef USE_ICARUS
+#define DRIVER_icarus(X) X(icarus)
+#else
+#define DRIVER_icarus(X)
+#endif
+
+#ifdef USE_KLONDIKE
+#define DRIVER_klondike(X) X(klondike)
+#else
+#define DRIVER_klondike(X)
+#endif
+
+#ifdef USE_KNC
+#define DRIVER_knc(X) X(knc)
+#else
+#define DRIVER_knc(X)
+#endif
+
+#ifdef USE_MINION
+#define DRIVER_minion(X) X(minion)
+#else
+#define DRIVER_minion(X)
+#endif
+
+#ifdef USE_SP10
+#define DRIVER_sp10(X) X(sp10)
+#else
+#define DRIVER_sp10(X)
+#endif
+
+#ifdef USE_SP30
+#define DRIVER_sp30(X) X(sp30)
+#else
+#define DRIVER_sp30(X)
+#endif
+
+#ifdef USE_BITMAIN_SOC
+#define DRIVER_bitmain_soc(X) X(bitmain_soc)
+#else
+#define DRIVER_bitmain_soc(X)
+#endif
+
 #define FPGA_PARSE_COMMANDS(DRIVER_ADD_COMMAND) \
-	DRIVER_ADD_COMMAND(bitforce) \
-	DRIVER_ADD_COMMAND(modminer)
+	DRIVER_bitforce(DRIVER_ADD_COMMAND) \
+	DRIVER_modminer(DRIVER_ADD_COMMAND)
 
 #define ASIC_PARSE_COMMANDS(DRIVER_ADD_COMMAND) \
-	DRIVER_ADD_COMMAND(ants1) \
-	DRIVER_ADD_COMMAND(ants2) \
-	DRIVER_ADD_COMMAND(ants3) \
-	DRIVER_ADD_COMMAND(avalon) \
-	DRIVER_ADD_COMMAND(avalon2) \
-	DRIVER_ADD_COMMAND(avalon4) \
-	DRIVER_ADD_COMMAND(avalon7) \
-	DRIVER_ADD_COMMAND(avalon8) \
-	DRIVER_ADD_COMMAND(avalonm) \
-	DRIVER_ADD_COMMAND(bab) \
-	DRIVER_ADD_COMMAND(bflsc) \
-	DRIVER_ADD_COMMAND(bitfury) \
-	DRIVER_ADD_COMMAND(bitfury16) \
-	DRIVER_ADD_COMMAND(bitmineA1) \
-	DRIVER_ADD_COMMAND(blockerupter) \
-	DRIVER_ADD_COMMAND(cointerra) \
-	DRIVER_ADD_COMMAND(flow) \
-	DRIVER_ADD_COMMAND(gekko) \
-	DRIVER_ADD_COMMAND(dragonmintT1) \
-	DRIVER_ADD_COMMAND(hashfast) \
-	DRIVER_ADD_COMMAND(drillbit) \
-	DRIVER_ADD_COMMAND(hashratio) \
-	DRIVER_ADD_COMMAND(icarus) \
-	DRIVER_ADD_COMMAND(klondike) \
-	DRIVER_ADD_COMMAND(knc) \
-	DRIVER_ADD_COMMAND(minion) \
-	DRIVER_ADD_COMMAND(sp10) \
-	DRIVER_ADD_COMMAND(sp30) \
-	DRIVER_ADD_COMMAND(bitmain_soc)
+	DRIVER_ants1(DRIVER_ADD_COMMAND) \
+	DRIVER_ants2(DRIVER_ADD_COMMAND) \
+	DRIVER_ants3(DRIVER_ADD_COMMAND) \
+	DRIVER_avalon(DRIVER_ADD_COMMAND) \
+	DRIVER_avalon2(DRIVER_ADD_COMMAND) \
+	DRIVER_avalon4(DRIVER_ADD_COMMAND) \
+	DRIVER_avalon7(DRIVER_ADD_COMMAND) \
+	DRIVER_avalon8(DRIVER_ADD_COMMAND) \
+	DRIVER_avalonm(DRIVER_ADD_COMMAND) \
+	DRIVER_bab(DRIVER_ADD_COMMAND) \
+	DRIVER_bflsc(DRIVER_ADD_COMMAND) \
+	DRIVER_bitfury(DRIVER_ADD_COMMAND) \
+	DRIVER_bitfury16(DRIVER_ADD_COMMAND) \
+	DRIVER_bitmineA1(DRIVER_ADD_COMMAND) \
+	DRIVER_blockerupter(DRIVER_ADD_COMMAND) \
+	DRIVER_cointerra(DRIVER_ADD_COMMAND) \
+	DRIVER_flow(DRIVER_ADD_COMMAND) \
+	DRIVER_gekko(DRIVER_ADD_COMMAND) \
+	DRIVER_dragonmintT1(DRIVER_ADD_COMMAND) \
+	DRIVER_hashfast(DRIVER_ADD_COMMAND) \
+	DRIVER_drillbit(DRIVER_ADD_COMMAND) \
+	DRIVER_hashratio(DRIVER_ADD_COMMAND) \
+	DRIVER_icarus(DRIVER_ADD_COMMAND) \
+	DRIVER_klondike(DRIVER_ADD_COMMAND) \
+	DRIVER_knc(DRIVER_ADD_COMMAND) \
+	DRIVER_minion(DRIVER_ADD_COMMAND) \
+	DRIVER_sp10(DRIVER_ADD_COMMAND) \
+	DRIVER_sp30(DRIVER_ADD_COMMAND) \
+	DRIVER_bitmain_soc(DRIVER_ADD_COMMAND)
 
 #define DRIVER_PARSE_COMMANDS(DRIVER_ADD_COMMAND) \
 	FPGA_PARSE_COMMANDS(DRIVER_ADD_COMMAND) \
 	ASIC_PARSE_COMMANDS(DRIVER_ADD_COMMAND)
 
 #define DRIVER_ENUM(X) DRIVER_##X,
-#define DRIVER_PROTOTYPE(X) struct device_drv X##_drv;
+#define DRIVER_PROTOTYPE(X) extern struct device_drv X##_drv;
 
 /* Create drv_driver enum from DRIVER_PARSE_COMMANDS macro */
 enum drv_driver {

--- a/usbutils.c
+++ b/usbutils.c
@@ -4108,22 +4108,54 @@ void usb_cleanup(void)
 	for (i = 0; i < total_devices; i++) {
 		cgpu = devices[i];
 		switch (cgpu->drv->drv_id) {
+#ifdef USE_BFLSC
 			case DRIVER_bflsc:
+#endif
+#ifdef USE_BITFORCE
 			case DRIVER_bitforce:
+#endif
+#ifdef USE_BITFURY
 			case DRIVER_bitfury:
+#endif
+#ifdef USE_COINTERRA
 			case DRIVER_cointerra:
+#endif
+#ifdef USE_DRILLBIT
 			case DRIVER_drillbit:
+#endif
+#ifdef USE_GEKKO
 			case DRIVER_gekko:
+#endif
+#ifdef USE_MODMINER
 			case DRIVER_modminer:
+#endif
+#ifdef USE_ICARUS
 			case DRIVER_icarus:
+#endif
+#ifdef USE_AVALON
 			case DRIVER_avalon:
+#endif
+#ifdef USE_AVALON2
 			case DRIVER_avalon2:
+#endif
+#ifdef USE_AVALON4
 			case DRIVER_avalon4:
+#endif
+#ifdef USE_AVALON7
 			case DRIVER_avalon7:
+#endif
+#ifdef USE_AVALON8
 			case DRIVER_avalon8:
+#endif
+#ifdef USE_AVALON_MINER
 			case DRIVER_avalonm:
+#endif
+#ifdef USE_KLONDIKE
 			case DRIVER_klondike:
+#endif
+#ifdef USE_HASHFAST
 			case DRIVER_hashfast:
+#endif
 				DEVWLOCK(cgpu, pstate);
 				release_cgpu(cgpu);
 				DEVWUNLOCK(cgpu, pstate);


### PR DESCRIPTION
This PR fixes several build issues encountered when compiling cgminer on Ubuntu 24.04, where the default GCC/binutils toolchain is stricter about symbol duplication and undefined references.

